### PR TITLE
Make url_to_contents much faster by processing in the same thread.

### DIFF
--- a/inc/class-wp-cli-command.php
+++ b/inc/class-wp-cli-command.php
@@ -8,7 +8,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 	/**
 	 * Get the contents of a URL that would be used for a statis page.
 	 *
-	 * @synopsis <url> [--replace-from=<from>] [--replace-to=<to>]
+	 * @synopsis [<url>] [--replace-from=<from>] [--replace-to=<to>]
 	 */
 	public function output( $args, $args_assoc ) {
 		if ( ! empty( $args_assoc['replace-from'] ) ) {
@@ -16,7 +16,12 @@ class WP_CLI_Command extends \WP_CLI_Command {
 				return str_replace( $args_assoc['replace-from'], $args_assoc['replace-to'], $contents );
 			});
 		}
-		echo replace_urls( get_url_contents( $args[0] ) );
+
+		$urls = ! empty( $args[0] ) ? [ $args[0] ] : get_site_urls();
+
+		$contents = array_map( __NAMESPACE__ . '\\get_url_contents', $urls );
+
+		print_r( $contents );
 	}
 
 	/**
@@ -61,7 +66,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 
 		if ( ! empty( $args[0] ) ) {
 			add_filter( 'static_page_destination_directory', function( $dir ) use ( $args ) {
-				return realpath( $args[0] );
+				return $args[0];
 			});
 		}
 		array_map( function( $content, $url ) use ( $progress ) {


### PR DESCRIPTION
Instead of doing a loop-back per URL, try to tear down / re set up all the global state for each URL. This works pretty well, however the "include_once" flag on `locate_template` is a blocker for this. `get_header` etc are called with this, so it's not actually possible right now to call `get_header` twice in one PHP execution.

Another potential angle would be to Fork the process before any template is rendered, and then commincate with the parent process via a socket with the output, though that coul be quite tricky.