### PR TITLE
POC: Use pcntl_fork to run save command from different thread

### DIFF
--- a/inc/class-wp-cli-command.php
+++ b/inc/class-wp-cli-command.php
@@ -67,7 +67,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 		$progress = WP_CLI\Utils\make_progress_bar( 'Fetching & Saving pages', count( $urls ) );
 
 		$config = $args_assoc['config'] ?? null;
-		$replace_form = $args_assoc['replace-from'] ?? '';
+		$replace_from = $args_assoc['replace-from'] ?? '';
 		$replace_to = $args_assoc['replace-to'] ?? '';
 		$output_dir = $args[0] ?? '';
 
@@ -92,9 +92,9 @@ class WP_CLI_Command extends \WP_CLI_Command {
 					$content = '';
 				}
 
-				if ( ! empty( $replace_form ) ) {
-					add_filter( 'static_page_replace_urls_in_content', function( $contents ) use ( $replace_form, $replace_to ) {
-						return str_replace( $replace_form, $replace_to, $contents );
+				if ( ! empty( $replace_from ) ) {
+					add_filter( 'static_page_replace_urls_in_content', function( $contents ) use ( $replace_from, $replace_to ) {
+						return str_replace( $replace_from, $replace_to, $contents );
 					});
 				}
 

--- a/inc/class-wp-cli-command.php
+++ b/inc/class-wp-cli-command.php
@@ -18,6 +18,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 		}
 
 		$urls = ! empty( $args[0] ) ? [ $args[0] ] : get_site_urls( $args_assoc['config'] );
+		$urls = array_unique( $urls );
 
 		$contents = array_map( __NAMESPACE__ . '\\get_url_contents', $urls );
 

--- a/inc/class-wp-cli-command.php
+++ b/inc/class-wp-cli-command.php
@@ -8,7 +8,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 	/**
 	 * Get the contents of a URL that would be used for a statis page.
 	 *
-	 * @synopsis --config=<config> [<url>] [--replace-from=<from>] [--replace-to=<to>]
+	 * @synopsis [--config=<config>] [<url>] [--replace-from=<from>] [--replace-to=<to>]
 	 */
 	public function output( $args, $args_assoc ) {
 		if ( ! empty( $args_assoc['replace-from'] ) ) {
@@ -19,23 +19,21 @@ class WP_CLI_Command extends \WP_CLI_Command {
 
 		$urls = ! empty( $args[0] ) ? [ $args[0] ] : get_site_urls( $args_assoc['config'] );
 
-		foreach ( $urls as &$url ) {
-			$url = get_url_contents( $url, $args_assoc['config'] );
-			if ( is_wp_error( $url ) ) {
-				WP_CLI::warning( $url->get_error_message() );
-				continue;
-			}
+		$contents = array_map( __NAMESPACE__ . '\\get_url_contents', $urls );
 
-			$url = replace_urls( $url, $args_assoc['config'] );
-		}
+		$contents = array_map( __NAMESPACE__ . '\\replace_urls', $contents );
 
-		print_r( $urls );
+		array_map( function( $content, $url ) use ( $args_assoc ) {
+			save_contents_for_url( $content, $url, $args_assoc['config'] );
+		}, $contents, $urls );
+
+		print_r( $contents );
 	}
 
 	/**
 	 * Get all the URLs that would be saved to static pages.
 	 *
-	 * @synopsis --config=<config>
+	 * @synopsis [--config=<config>]
 	 */
 	public function urls( $args, $args_assoc ) {
 		$args_assoc = wp_parse_args( $args_assoc, array(
@@ -47,7 +45,7 @@ class WP_CLI_Command extends \WP_CLI_Command {
 	/**
 	 * Get all the assets that would be saved to static pages.
 	 *
-	 * @synopsis --config=<config>
+	 * @synopsis [--config=<config>]
 	 */
 	public function assets( $args, $args_assoc ) {
 		$args_assoc = wp_parse_args( $args_assoc, array(
@@ -59,94 +57,109 @@ class WP_CLI_Command extends \WP_CLI_Command {
 	/**
 	 * Save the contents to disk (or the destination directory).
 	 *
-	 * @synopsis --config=<config> [<path>] [--page-url=<url>] [--replace-from=<from>] [--replace-to=<to>] [--verbose]
+	 * @synopsis [--config=<config>] [<path>] [--page-url=<url>] [--replace-from=<from>] [--replace-to=<to>] [--verbose]
 	 */
 	public function save( $args, $args_assoc ) {
 		$urls = ! empty( $args_assoc['page-url'] ) ? [ $args_assoc['page-url'] ] : get_site_urls( $args_assoc['config'] );
+		$urls = array_unique( $urls );
 
-		$progress = WP_CLI\Utils\make_progress_bar( 'Fetching pages', count( $urls ) );
-		$contents = array_map( function( $url ) use ( $progress, $args_assoc ) {
-			$contents = get_url_contents( $url, $args_assoc['config'] );
-			if ( is_wp_error( $contents ) ) {
-				WP_CLI::warning( $contents->get_error_message() );
-				$contents = '';
-			}
+		$progress = WP_CLI\Utils\make_progress_bar( 'Fetching & Saving pages', count( $urls ) );
 
+		$config = $args_assoc['config'] ?? null;
+		$replace_form = $args_assoc['replace-from'] ?? '';
+		$replace_to = $args_assoc['replace-to'] ?? '';
+		$output_dir = $args[0] ?? '';
+
+		$status = null;
+		foreach( $urls as $url ) {
 			$progress->tick();
-			return $contents;
-		}, $urls );
-		$progress->finish();
 
-		if ( ! empty( $args_assoc['replace-from'] ) ) {
-			add_filter( 'static_page_replace_urls_in_content', function( $contents ) use ( $args_assoc ) {
-				return str_replace( $args_assoc['replace-from'], $args_assoc['replace-to'], $contents );
-			});
-		}
+			$pid = \pcntl_fork();
 
-		foreach ( $contents as &$content ) {
-			$content = replace_urls( $content, $args_assoc['config'] );
-		}
-
-		$progress = WP_CLI\Utils\make_progress_bar( 'Saving pages', count( $urls ) );
-
-		if ( ! empty( $args[0] ) ) {
-			add_filter( 'static_page_destination_directory', function( $dir ) use ( $args ) {
-				return $args[0];
-			});
-		}
-		array_map( function( $content, $url ) use ( $progress, $args_assoc ) {
-			$progress->tick();
-			if ( ! empty( $args_assoc['verbose'] ) ) {
-				WP_CLI::line( 'Saving ' . $url );
-			}
-
-			$options = [
-				'user_id' => get_current_user_id(),
-				'context' => '',
-				'action'  => '',
-			];
-
-			$post_id = url_to_postid( $url );
-			if ( ! empty( $post_id ) ) {
-				$post = get_post( $post_id );
-				if ( $post instanceof  \WP_Post && $post->post_type === 'page' ) {
-					$options['context'] = 'page';
-					$options['action']  = 'wp_cli_netstorage_publish';
-				}
+			if ( $pid == - 1 ) {
+				die( 'could not fork' );
+			} else if ( $pid ) {
+				// we are the parent
+				\pcntl_wait( $status ); //Protect against Zombie children
 			} else {
-				$parsed_url = wp_parse_url( $url );
-				if ( ! empty( $parsed_url ) ) {
-					$args = array(
-						'meta_key'   => 'netstorage_path',
-						'meta_value' => substr( $parsed_url['path'], 1 ),
-						'post_type'  => 'netstorage-file',
-					);
+				// Now we are in child process.
 
-					$query = new \WP_Query( $args );
-					if ( ! empty( $query->post ) && $query->post->ID === $post_id ) { // Get the first post assuming no posts will have the same path.
-						$options['context'] = 'netstorage-file';
+				$content = get_url_contents( $url, $config );
+				// $content = get_url_contents( $url, $args_assoc['config'] );
+				if ( is_wp_error( $content ) ) {
+					WP_CLI::warning( $content->get_error_message() );
+					$content = '';
+				}
+
+				if ( ! empty( $replace_form ) ) {
+					add_filter( 'static_page_replace_urls_in_content', function( $contents ) use ( $replace_form, $replace_to ) {
+						return str_replace( $replace_form, $replace_to, $contents );
+					});
+				}
+
+				$content = replace_urls( $content, $config );
+
+				if ( ! empty( $output_dir ) ) {
+					add_filter( 'static_page_destination_directory', function( $dir ) use ( $output_dir ) {
+						return $output_dir;
+					});
+				}
+
+				$options = [
+					'user_id' => get_current_user_id(),
+					'context' => '',
+					'action'  => '',
+				];
+
+				$post_id = url_to_postid( $url );
+				if ( ! empty( $post_id ) ) {
+					$post = get_post( $post_id );
+					if ( $post instanceof  \WP_Post && $post->post_type === 'page' ) {
+						$options['context'] = 'page';
 						$options['action']  = 'wp_cli_netstorage_publish';
 					}
+				} else {
+					$parsed_url = wp_parse_url( $url );
+					if ( ! empty( $parsed_url ) ) {
+						$args = array(
+							'meta_key'   => 'netstorage_path',
+							'meta_value' => substr( $parsed_url['path'], 1 ),
+							'post_type'  => 'netstorage-file',
+						);
+
+						$query = new \WP_Query( $args );
+						if ( ! empty( $query->post ) && $query->post->ID === $post_id ) { // Get the first post assuming no posts will have the same path.
+							$options['context'] = 'netstorage-file';
+							$options['action']  = 'wp_cli_netstorage_publish';
+						}
+					}
 				}
+
+				/**
+				 * Action hook to pass data about netstorage export.
+				 *
+				 * @param int   $post_id  Post ID.
+				 * @param array $options  Netstorage update data.
+				 */
+				do_action( 'ns_wp_cli_export_page', $post_id, $options );
+
+				save_contents_for_url( $content, $url, $config );
+
+				exit();
 			}
 
-			/**
-			 * Action hook to pass data about netstorage export.
-			 *
-			 * @param int   $post_id  Post ID.
-			 * @param array $options  Netstorage update data.
-			 */
-			do_action( 'ns_wp_cli_export_page', $post_id, $options );
+		}
 
-			save_contents_for_url( $content, $url, $args_assoc['config'] );
-		}, $contents, $urls );
+		while ( \pcntl_waitpid( 0, $status ) != - 1 ) {
+			// Waiting till the pid finished.
+		}
 
 		$progress->finish();
 	}
 
 	/**
 	 * @subcommand save-assets
-	 * @synopsis --config=<config> [<path>] [--include=<whitelist-regex>] [--verbose]
+	 * @synopsis [--config=<config>] [<path>] [--include=<whitelist-regex>] [--verbose]
 	 */
 	public function save_assets( $args, $args_assoc ) {
 		if ( ! empty( $args_assoc['include'] ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -158,7 +158,7 @@ function get_site_urls( $config = null ) {
 /**
  * Get the page contents of a URL.
  *
- * @param  string $url
+ * @param  string $url     URL to get the content from.
  * @param  mixed  $config  Option config object that will be passed to filters etc.
  * @param  int    $post_id Current Post ID.
  * @return string|WP_Error URL contents on success, error object otherwise.
@@ -189,9 +189,9 @@ function get_url_with_remote_request( $url, $config = null ) {
 	$code = wp_remote_retrieve_response_code( $response );
 	if ( $code !== 200 ) {
 		return new WP_Error(
-				'static-page.get_url_contents.non_200',
-				sprintf( __( 'Non-200 response (%1$d) returned from %2$s', 'static-page' ), $code, $url ),
-				[ 'response' => $response ]
+			'static-page.get_url_contents.non_200',
+			sprintf( __( 'Non-200 response (%1$d) returned from %2$s', 'static-page' ), $code, $url ),
+			[ 'response' => $response ]
 		);
 	}
 
@@ -201,7 +201,7 @@ function get_url_with_remote_request( $url, $config = null ) {
 /**
  * Get the page contents of a URL.
  *
- * @param  string $url
+ * @param  string $url     URL to get the content from.
  * @param  mixed  $config  Option config object that will be passed to filters etc.
  * @return string|WP_Error URL contents on success, error object otherwise.
  */
@@ -254,6 +254,11 @@ function get_url_with_template_loader( $url, $config = null ) {
 	return ob_get_clean();
 }
 
+/**
+ * Clean up global query vars.
+ *
+ * @return void
+ */
 function _cleanup_query_vars() {
 	// clean out globals to stop them polluting wp and wp_query
 	foreach ( $GLOBALS['wp']->public_query_vars as $v )
@@ -273,7 +278,14 @@ function _cleanup_query_vars() {
 	}
 }
 
-
+/**
+ * Replace urls inside the content.
+ *
+ * @param string $content HTML Content.
+ * @param mixed $config Option config object that will be passed to filters etc.
+ *
+ * @return mixed|void
+ */
 function replace_urls( $content, $config = null ) {
 	return apply_filters( 'static_page_replace_urls_in_content', $content, $config );
 }

--- a/plugin.php
+++ b/plugin.php
@@ -164,7 +164,21 @@ function get_site_urls( $config = null ) {
  * @return string|WP_Error URL contents on success, error object otherwise.
  */
 function get_url_contents( $url, $config = null, $post_id = null ) {
-	// for now we just do a loop back
+	if ( extension_loaded( 'pcntl' ) && defined( 'WP_CLI' ) ) {
+		return get_url_with_template_loader( $url );
+	}
+	return get_url_with_remote_request( $url, $config );
+}
+
+/**
+ * Fetch Content with Remote Request
+ *
+ * @param  string $url
+ * @param  mixed  $config  Option config object that will be passed to filters etc.
+ *
+ * @return string|WP_Error URL contents on success, error object otherwise.
+ */
+function get_url_with_remote_request( $url, $config = null ) {
 	$url = apply_filters( 'static_page_get_url_contents_request_url', $url, $config );
 	$args = apply_filters( 'static_page_get_url_contents_request_args', array(), $config );
 	$response = wp_remote_get( $url, $args );
@@ -175,18 +189,93 @@ function get_url_contents( $url, $config = null, $post_id = null ) {
 	$code = wp_remote_retrieve_response_code( $response );
 	if ( $code !== 200 ) {
 		return new WP_Error(
-			'static-page.get_url_contents.non_200',
-			sprintf( __( 'Non-200 response (%1$d) returned from %2$s', 'static-page' ), $code, $url ),
-			[ 'response' => $response ]
+				'static-page.get_url_contents.non_200',
+				sprintf( __( 'Non-200 response (%1$d) returned from %2$s', 'static-page' ), $code, $url ),
+				[ 'response' => $response ]
 		);
 	}
 
 	return wp_remote_retrieve_body( $response );
 }
 
+/**
+ * Get the page contents of a URL.
+ *
+ * @param  string $url
+ * @param  mixed  $config  Option config object that will be passed to filters etc.
+ * @return string|WP_Error URL contents on success, error object otherwise.
+ */
+function get_url_with_template_loader( $url, $config = null ) {
+	$url = apply_filters( 'static_page_get_url_contents_request_url', $url, $config );
+
+	$_GET = $_POST = array();
+
+	foreach ( array( 'query_string', 'id', 'postdata', 'authordata', 'day', 'currentmonth', 'page', 'pages', 'multipage', 'more', 'numpages', 'pagenow') as $v) {
+		if ( isset( $GLOBALS[$v] ) ) unset( $GLOBALS[$v] );
+	}
+
+	$parts = parse_url($url);
+
+	if ( isset( $parts['scheme'] ) ) {
+		$req = $parts['path'];
+		if ( isset( $parts['query'] ) ) {
+			$req .= '?' . $parts['query'];
+			// parse the url query vars into $_GET
+			parse_str( $parts['query'], $_GET );
+		}
+	} else {
+		$req = $url;
+	}
+
+	if ( ! isset( $parts['query'] ) ) {
+		$parts['query'] = '';
+	}
+
+	$_SERVER['REQUEST_URI'] = $req;
+	unset( $_SERVER['PATH_INFO'] );
+
+	unset( $GLOBALS['wp_query'], $GLOBALS['wp_the_query'] );
+
+	$GLOBALS['wp_the_query'] = new \WP_Query();
+	$GLOBALS['wp_query']     = $GLOBALS['wp_the_query'];
+	$GLOBALS['wp']           = new \WP();
+	_cleanup_query_vars();
+
+	$GLOBALS['wp']->main( $parts['query'] );
+
+	if ( ! defined( 'WP_USE_THEMES' ) ) {
+		define( 'WP_USE_THEMES', true );
+	}
+
+	remove_action( 'template_redirect', 'redirect_canonical' );
+
+	ob_start();
+	require ABSPATH . WPINC . '/template-loader.php';
+	return ob_get_clean();
+}
+
+function _cleanup_query_vars() {
+	// clean out globals to stop them polluting wp and wp_query
+	foreach ( $GLOBALS['wp']->public_query_vars as $v )
+		unset( $GLOBALS[$v] );
+
+	foreach ( $GLOBALS['wp']->private_query_vars as $v )
+		unset( $GLOBALS[$v] );
+
+	foreach ( get_taxonomies( array() , 'objects' ) as $t ) {
+		if ( ! empty( $t->query_var ) )
+			$GLOBALS['wp']->add_query_var( $t->query_var );
+	}
+
+	foreach ( get_post_types( array() , 'objects' ) as $t ) {
+		if ( ! empty( $t->query_var ) )
+			$GLOBALS['wp']->add_query_var( $t->query_var );
+	}
+}
+
+
 function replace_urls( $content, $config = null ) {
-	$content = apply_filters( 'static_page_replace_urls_in_content', $content, $config );
-	return $content;
+	return apply_filters( 'static_page_replace_urls_in_content', $content, $config );
 }
 
 /**


### PR DESCRIPTION
This PR is a refresh from the original PR #1  from Joe.

Like the issue mentioned in previous PR from Joe:
> the "include_once" flag on locate_template is a blocker for this. get_header etc are called with this, so it's not actually possible right now to call get_header twice in one PHP execution.

And I tried to fork the main process to avoid multiple php `include`. And it does pretty well.
Currently only apply this to wpcli command to avoid php max execution timeout. And in production environment, mostly this will be done from cavalcade which run on wpcli. 

The other challenge i have in mind is how to handle the fallback when the main process get killed? 

@joehoyle what is your opinion on this PR?