### PR TITLE
Add post_id to replace urls function

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -198,8 +198,8 @@ function get_url_contents( $url, $config = null, $post_id = null ) {
 	return $content;
 }
 
-function replace_urls( $content, $config = null ) {
-	$content = apply_filters( 'static_page_replace_urls_in_content', $content, $config );
+function replace_urls( $content, $config = null, $post_id = null ) {
+	$content = apply_filters( 'static_page_replace_urls_in_content', $content, $config, $post_id );
 	return $content;
 }
 


### PR DESCRIPTION
This PR add `post_id` as 3rd params into the replace_urls function.

The goal is to allow 3rd party when using the filter `static_page_replace_urls_in_content` has the context of the current post it try to replace the urls.
The sample case is when 3rd party want to conditionally do the url replacement.